### PR TITLE
Fix failing test E0308

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl<W: io::Write> RtssWriter<W> {
     /// use rtss::{RtssWriter, DurationExt};
     ///
     /// fn main() -> io::Result<()> {
-    ///     let mut writer = RtssWriter::new(io::stdout(), Duration::human_string, '|', &Instant::now());
+    ///     let mut writer = RtssWriter::new(io::stdout(), Duration::human_string, '|', Instant::now());
     ///     writer.write(b"Hello!\n")?;
     ///     writer.write(b"World!\n")?;
     ///     Ok(())


### PR DESCRIPTION
I've been using `rtss` on NixOS and contributed a package definition upstream. I noticed that one of the doctests was failing:
```
running tests                                                                                                                                                                                                                                  
Running cargo test --release --target x86_64-unknown-linux-gnu --frozen --                                                                                                                                                                     
   Compiling rtss v0.6.1 (/build/rtss)                                                                                                                                                                                                         
    Finished release [optimized] target(s) in 0.30s                                                                                                                                                                                            
     Running target/x86_64-unknown-linux-gnu/release/deps/rtss-93270af92de2f40e                                                                                                                                                                
                                                                                                                                                                                                                                               
running 0 tests                                                                                                                                                                                                                                
                                                                                                                                                                                                                                               
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out                                                                                                                                                                     
                                                                                                                                                                                                                                               
     Running target/x86_64-unknown-linux-gnu/release/deps/rtss-8d2a66c3d913ebdd                                                                                                                                                                
                                                                                                                                                                                                                                               
running 0 tests                                                                                                                                                                                                                                
                                                                                                                                                                                                                                               
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out                                                                                                                                                                     
                                                                                                                                                                                                                                               
   Doc-tests rtss                                                                                                                                                                                                                              
                                                                                                                                                                                                                                               
running 1 test                                                                                                                                                                                                                                 
test src/lib.rs - RtssWriter<W>::new (line 107) ... FAILED                                                                                                                                                                                     
                                                                                                                                                                                                                                               
failures:                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                               
---- src/lib.rs - RtssWriter<W>::new (line 107) stdout ----                                                                                                                                                                                    
error[E0308]: mismatched types                                                                                                                                                                                                                 
 --> src/lib.rs:115:81                                                                                                                                                                                                                         
  |                                                                                                                                                                                                                                            
9 |     let mut writer = RtssWriter::new(io::stdout(), Duration::human_string, '|', &Instant::now()); // foo                                                                                                                                   
  |                                                                                 ^^^^^^^^^^^^^^^                                                                                                                                            
  |                                                                                 |                                                                                                                                                          
  |                                                                                 expected struct `std::time::Instant`, found `&std::time::Instant`                                                                                          
  |                                                                                 help: consider removing the borrow: `Instant::now()`                                                                                                       
                                                                                                                                                                                                                                               
error: aborting due to previous error                                                                                                                                                                                                          
                                                                                                                                                                                                                                               
For more information about this error, try `rustc --explain E0308`.                                                                                                                                                                            
Couldn't compile the test.                                                                                                                                                                                                                     
                                                                                                                                                                                                                                               
failures:                                                                                                                                                                                                                                      
    src/lib.rs - RtssWriter<W>::new (line 107)                                                                                                                                                                                                 
                                                                                                                                                                                                                                               
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out                                                                                                                                                                 

error: test failed, to rerun pass '--doc'
```

I tried the suggestion given by the compiler, and the doctests now pass:
```
Doc-tests rtss                                                                                                                                                                                                                              
                                                                                                                                                                                                                                               
running 1 test                                                                                                                                                                                                                                 
test src/lib.rs - RtssWriter<W>::new (line 107) ... ok 
```